### PR TITLE
Handle sponsor presets via URL parameters

### DIFF
--- a/Model/Db/Table/Migareference.php
+++ b/Model/Db/Table/Migareference.php
@@ -4317,15 +4317,23 @@ $query_option_value.=" GROUP BY mis.user_id ORDER BY mis.invoice_surname ASC, mi
             return []; // match is_agent() style
         }
 
-    $query_option = "
-        SELECT *
-        FROM `migareference_app_agents`
-        JOIN `customer` ON `customer`.`customer_id` = `migareference_app_agents`.`user_id`
-        WHERE `migareference_app_agents`.`app_id` = {$app_id}
-          AND `customer`.`email` = " . $this->_db->quote($email);
+        $query_option = "
+            SELECT DISTINCT
+                agents.user_id,
+                agents.agent_type,
+                customer.firstname,
+                customer.lastname,
+                customer.email
+            FROM `migareference_app_agents` AS agents
+            INNER JOIN `customer`
+                ON `customer`.`customer_id` = `agents`.`user_id`
+               AND `customer`.`app_id` = {$app_id}
+            WHERE `agents`.`app_id` = {$app_id}
+              AND `customer`.`email` = " . $this->_db->quote($email) . "
+            ORDER BY customer.lastname, customer.firstname";
 
-            $res_option   = $this->_db->fetchAll($query_option);
-      
+        $res_option   = $this->_db->fetchAll($query_option);
+
         return $res_option; // [] or [0 => row]
     }
 

--- a/resources/design/desktop/flat/template/migareference/application/includes/optinform.phtml
+++ b/resources/design/desktop/flat/template/migareference/application/includes/optinform.phtml
@@ -532,12 +532,82 @@
                            $("#profession_id").html("").append(data.profession_list);
                            $("#c-img-con").html("").append(data.c_img);
                            $("#track_id").val(data.track_id);
-						   <?php if (!$optin_setting_data) : ?>
+                                                   <?php if (!$optin_setting_data) : ?>
                            $(".sponsor_list").css("display", data.sponsor_display);
                            $(".province_list").css("display", data.province_display);
-						   <?php endif; ?> 
-                           const urlParams = new URLSearchParams(window.location.search);                               
-                           $("#sponsord_by").val(urlParams.get('agval'));
+                                                   <?php endif; ?>
+                           const urlParams = new URLSearchParams(window.location.search);
+                           const sponsorIdParam = (urlParams.get('sponsor_id') || '').trim();
+                           const sponsorEmailParam = (urlParams.get('sponsor_email') || '').trim();
+                           const agvalParam = urlParams.get('agval');
+                           $("#sponsord_by").val(agvalParam);
+                           const $sponsorSelect = $("#sponsor_id");
+                           const $form = $("#ref_form");
+
+                           function lockSponsor(agentId, agentLabel) {
+                               if (!$sponsorSelect.length) {
+                                   return;
+                               }
+                               const optionValue = agentId !== null && agentId !== undefined ? String(agentId) : '';
+                               if (!optionValue) {
+                                   return;
+                               }
+                               const resolvedLabel = agentLabel !== undefined && agentLabel !== null ? String(agentLabel).trim() : '';
+                               const labelText = resolvedLabel !== '' ? resolvedLabel : optionValue;
+                               if (!$sponsorSelect.find('option[value="' + optionValue + '"]').length) {
+                                   const option = new Option(labelText, optionValue, true, true);
+                                   $sponsorSelect.append(option);
+                               }
+                               if ($sponsorSelect.find('option[value="' + optionValue + '"]').length) {
+                                   $sponsorSelect.val(optionValue);
+                                   $sponsorSelect.prop('disabled', true);
+                                   if ($form.length) {
+                                       let $hidden = $("#locked_sponsor_id");
+                                       if (!$hidden.length) {
+                                           $hidden = $('<input>', { type: 'hidden', id: 'locked_sponsor_id', name: 'sponsor_id' });
+                                           $form.append($hidden);
+                                       }
+                                       $hidden.val(optionValue);
+                                   }
+                                   $("#sponsord_by").val(optionValue);
+                               }
+                           }
+
+                           function resolveSponsorByEmail(email) {
+                               if (!email) {
+                                   return;
+                               }
+                               $.ajax({
+                                   url: '<?php echo $this->getUrl('migareference/public_optinlanding/resolvesponsorbyemail'); ?>',
+                                   type: 'POST',
+                                   dataType: 'json',
+                                   data: {
+                                       app_id: <?php echo  $app_id ?>,
+                                       email: email
+                                   }
+                               }).done(function(response) {
+                                   if (response && response.success && response.count > 0 && response.data && response.data[0]) {
+                                       const agent = response.data[0];
+                                       const labelParts = [];
+                                       if (agent.firstname) { labelParts.push(agent.firstname); }
+                                       if (agent.lastname) { labelParts.push(agent.lastname); }
+                                       let label = labelParts.join(' ').trim();
+                                       if (!label) {
+                                           label = agent.email || email;
+                                       }
+                                       lockSponsor(agent.user_id, label);
+                                   }
+                               });
+                           }
+
+                           if (sponsorIdParam) {
+                               lockSponsor(sponsorIdParam);
+                           } else if (sponsorEmailParam) {
+                               resolveSponsorByEmail(sponsorEmailParam);
+                           } else {
+                               $sponsorSelect.prop('disabled', false);
+                               $("#locked_sponsor_id").remove();
+                           }
                         });
                     }
                 &lt;/script&gt;
@@ -1151,6 +1221,11 @@
         });
     });
     //
+    const urlParams = new URLSearchParams(window.location.search);
+    const sponsorIdParam = (urlParams.get('sponsor_id') || '').trim();
+    const sponsorEmailParam = (urlParams.get('sponsor_email') || '').trim();
+    const agvalParam = urlParams.get('agval');
+
     loadSettings();
     function loadSettings() {
     $.ajax({
@@ -1162,8 +1237,85 @@
             }
         })
         .done(function(data) {
-            console.log("Data is loaded");
-            console.log(data);
+            $("#sponsor_id").html("").append(data.agent_option);
+            $("#province_id").html("").append(data.province_list);
+            $("#job_id").html("").append(data.job_list);
+            $("#profession_id").html("").append(data.profession_list);
+            $("#profession_id").html("").append(data.profession_list);
+            $("#c-img-con").html("").append(data.c_img);
+            $("#track_id").val(data.track_id);
+                            <?php if (!$optin_setting_data) : ?>
+            $(".sponsor_list").css("display", data.sponsor_display);
+            $(".province_list").css("display", data.province_display);
+                            <?php endif; ?>
+            $("#sponsord_by").val(agvalParam);
+            const $sponsorSelect = $("#sponsor_id");
+            const $form = $("#ref_form");
+
+            function lockSponsor(agentId, agentLabel) {
+                if (!$sponsorSelect.length) {
+                    return;
+                }
+                const optionValue = agentId !== null && agentId !== undefined ? String(agentId) : '';
+                if (!optionValue) {
+                    return;
+                }
+                const resolvedLabel = agentLabel !== undefined && agentLabel !== null ? String(agentLabel).trim() : '';
+                const labelText = resolvedLabel !== '' ? resolvedLabel : optionValue;
+                if (!$sponsorSelect.find('option[value="' + optionValue + '"]').length) {
+                    const option = new Option(labelText, optionValue, true, true);
+                    $sponsorSelect.append(option);
+                }
+                if ($sponsorSelect.find('option[value="' + optionValue + '"]').length) {
+                    $sponsorSelect.val(optionValue);
+                    $sponsorSelect.prop('disabled', true);
+                    if ($form.length) {
+                        let $hidden = $("#locked_sponsor_id");
+                        if (!$hidden.length) {
+                            $hidden = $('<input>', { type: 'hidden', id: 'locked_sponsor_id', name: 'sponsor_id' });
+                            $form.append($hidden);
+                        }
+                        $hidden.val(optionValue);
+                    }
+                    $("#sponsord_by").val(optionValue);
+                }
+            }
+
+            function resolveSponsorByEmail(email) {
+                if (!email) {
+                    return;
+                }
+                $.ajax({
+                    url: '<?php echo $this->getUrl('migareference/public_optinlanding/resolvesponsorbyemail'); ?>',
+                    type: 'POST',
+                    dataType: 'json',
+                    data: {
+                        app_id: <?php echo  $app_id ?>,
+                        email: email
+                    }
+                }).done(function(response) {
+                    if (response && response.success && response.count > 0 && response.data && response.data[0]) {
+                        const agent = response.data[0];
+                        const labelParts = [];
+                        if (agent.firstname) { labelParts.push(agent.firstname); }
+                        if (agent.lastname) { labelParts.push(agent.lastname); }
+                        let label = labelParts.join(' ').trim();
+                        if (!label) {
+                            label = agent.email || email;
+                        }
+                        lockSponsor(agent.user_id, label);
+                    }
+                });
+            }
+
+            if (sponsorIdParam) {
+                lockSponsor(sponsorIdParam);
+            } else if (sponsorEmailParam) {
+                resolveSponsorByEmail(sponsorEmailParam);
+            } else {
+                $sponsorSelect.prop('disabled', false);
+                $("#locked_sponsor_id").remove();
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- allow the opt-in embed snippet to read `sponsor_id` and `sponsor_email` URL parameters, automatically selecting and locking the sponsor dropdown when either resolves to an agent
- add a hidden fallback input so the locked sponsor value is submitted and call the public resolver endpoint when only an email is provided
- tighten the sponsor lookup query by joining the agent table with the customer table scoped to the current app

## Testing
- php -l Model/Db/Table/Migareference.php

------
https://chatgpt.com/codex/tasks/task_e_68d625201d34832db440666c376ef003