### PR TITLE
Sort agent lists in property settings view

### DIFF
--- a/features/migareference/assets/templates/l1/propertysettings.html
+++ b/features/migareference/assets/templates/l1/propertysettings.html
@@ -74,7 +74,7 @@
             value=""
           />
           <select
-            ng-options="item.name for item in agentList track by item.id"
+            ng-options="item.name for item in sortedAgentList track by item.id"
             style="
               width: 100%;
               padding: 8px;
@@ -95,7 +95,7 @@
           >
           <br />          
           <select
-            ng-options="item.name for item in partneragentList track by item.id"
+            ng-options="item.name for item in sortedPartneragentList track by item.id"
             style="
               width: 100%;
               padding: 8px;

--- a/features/migareference/js/controllers/invoicesettings.js
+++ b/features/migareference/js/controllers/invoicesettings.js
@@ -120,6 +120,8 @@ angular
       }
       $scope.itemList = [];
       $scope.agentList = [];
+      $scope.sortedAgentList = [];
+      $scope.sortedPartneragentList = [];
       $scope.blisterPackTemplates = [
         { id: 1, name: "Email/PUSH" },
         { id: 2, name: "Only Email" },
@@ -194,6 +196,33 @@ angular
         }
       };
 
+      function sortAgentCollection(collection) {
+        if (!collection) {
+          return [];
+        }
+        var list = collection;
+        if (!angular.isArray(list) && typeof list === "object") {
+          list = Object.keys(list)
+            .sort()
+            .map(function (key) {
+              return list[key];
+            });
+        }
+        return list
+          .slice()
+          .sort(function (first, second) {
+            var firstName = (first && first.name ? first.name : "").toString().toLowerCase();
+            var secondName = (second && second.name ? second.name : "").toString().toLowerCase();
+            if (firstName < secondName) {
+              return -1;
+            }
+            if (firstName > secondName) {
+              return 1;
+            }
+            return 0;
+          });
+      }
+
       $scope.getPropertysettings = function () {
         $scope.is_loading = true;
         Loader.show();
@@ -209,7 +238,17 @@ angular
             $scope.is_agent_list = data.is_agent_list;
             $scope.agentList = data.agent_list;
             $scope.partneragentList = data.partner_agent_list;
-            $scope.migareferenceformchange.sponsor_id = $scope.agentList[0];
+            $scope.sortedAgentList = sortAgentCollection(data.agent_list);
+            $scope.sortedPartneragentList = sortAgentCollection(
+              data.partner_agent_list
+            );
+            if (
+              typeof $scope.migareferenceformchange.sponsor_id === "undefined" &&
+              $scope.sortedAgentList.length > 0
+            ) {
+              $scope.migareferenceformchange.sponsor_id =
+                $scope.sortedAgentList[0];
+            }
             $scope.agnet_province_list = data.agnet_province_list;
             $scope.countries_count = data.countries_count;
             if (data.countries_count < 2) {


### PR DESCRIPTION
## Summary
- add front-end sorting for agent and partner lists on the property settings screen
- introduce a controller helper to build alphabetically sorted collections without touching PHP logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d630c25ab8832da31a25c9b6291e20