### PR TITLE
Add enroll URL sharing modal and backend support

### DIFF
--- a/controllers/Mobile/ViewController.php
+++ b/controllers/Mobile/ViewController.php
@@ -5458,6 +5458,9 @@ public function getexternallinksAction()
     $admin_data       = $migareference->is_admin($app_id,$user_id);
     $agent_data       = $migareference->is_agent($app_id,$user_id);
     $pre_settings     = $migareference->preReportsettigns($app_id);
+    $optin_setting    = (new Migareference_Model_Optinsetting())->find([
+      'app_id' => $app_id,
+    ]);
     $invoice_settings = $migareference->getpropertysettings($app_id,$user_id);
     $bitly_crede      = $migareference->getBitlycredentails($app_id);
     $total_earn       = $migareference->get_earnings($app_id,$user_id);
@@ -5544,6 +5547,19 @@ public function getexternallinksAction()
         $is_need_vat_id=1;
       }
     }
+    $enrolling_page_url   = '';
+    $enroll_sharing_msg   = '';
+    if ($optin_setting->getId()) {
+      $enrolling_page_url = trim((string) $optin_setting->getEnrollingPageUrl());
+      $enroll_sharing_msg = trim((string) $optin_setting->getEnrollSharingMessage());
+      if ($enrolling_page_url && $enroll_sharing_msg) {
+        $enroll_sharing_msg = str_replace(
+          ['@@app_name@@', '@@enroll_url@@'],
+          [$application->getName(), $enrolling_page_url],
+          $enroll_sharing_msg
+        );
+      }
+    }
     $payload  = [
         'success'           => true,
         'acurruncy'         => $curruncy,
@@ -5560,6 +5576,11 @@ public function getexternallinksAction()
         'reward_type'       => $pre_settings[0]['reward_type'],
         'agent_can_see'     => $pre_settings[0]['agent_can_see'],
         'agent_can_manage'  => $pre_settings[0]['agent_can_manage'],
+        'optin_settings'    => [
+          'enrolling_page_url'    => $enrolling_page_url,
+          'enroll_sharing_message'=> $enroll_sharing_msg,
+        ],
+        'enroll_settings_warning' => __('Enroll URL settings are missing. Please complete the settings to share the message.'),
         'is_howto_data_missing'=> $is_howto_data_missing,
         'is_apikey_missing'    => $is_apikey_missing,
         'is_howto_data_missing_err'=> __('Could not find data.'),

--- a/features/migareference/assets/templates/l1/view.html
+++ b/features/migareference/assets/templates/l1/view.html
@@ -74,7 +74,7 @@
         <!-- Add Report -->
         <div
           class="item item-body home-card-body add-report-bg-color"
-          ng-click="getPropertysettings(2)"
+          ng-click="shareEnrollUrl()"
           style="background:{{home_icos.add_property_bg_color }} !important;"
         >
           <img
@@ -511,4 +511,77 @@
     <!--END:Must login Panlae-->
   </ion-content>
   <!--END:Page COntent-->
+  <script id="enrollshare.html" type="text/ng-template">
+    <ion-modal-view style="top:20% !important;background:none !important">
+      <ion-content
+        style="height: fit-content !important;border-radius: 5px;background-color:#f7f7f7 !important"
+      >
+        <div class="card" style="padding:10px;">
+          <div ng-if="is_native_app">
+            <div>
+              <p style="font-weight: 500;color:gray;text-align:center">{{enrollShare.message}}</p>
+              <p style="font-weight: 500;color:#000;text-align:center;word-break:break-all">{{enrollShare.url}}</p>
+            </div>
+            <button
+              class="button button-full button-positive"
+              style="font-weight:600"
+              ng-click="shareEnrollNative()"
+            >
+              {{'Share Message' | translate}}
+            </button>
+            <button
+              class="button button-full button-positive"
+              style="margin-top:40px;font-weight:600"
+              ng-click="closeEnrollModal()"
+            >
+              {{'Cancel' | translate}}
+            </button>
+          </div>
+          <div ng-if="!is_native_app">
+            <div>
+              <p style="font-weight: 500;color:gray;text-align:center">{{enrollShare.message}}</p>
+              <p style="font-weight: 500;color:#000;text-align:center;word-break:break-all">{{enrollShare.url}}</p>
+            </div>
+            <div>
+              <button
+                class="button button-full button-positive"
+                style="font-weight:600"
+                ng-click="shareEnrollSocial('whatsapp')"
+              >
+                <i style="float:left;" class="icon ion-sb-whatsapp-outline"></i>{{'Whatsapp' | translate}}
+              </button>
+              <button
+                class="button button-full button-positive"
+                style="font-weight:600"
+                ng-click="shareEnrollSocial('email')"
+              >
+                <i style="float:left;" class="icon ion-ios-email-outline"></i>{{'Email' | translate}}
+              </button>
+              <button
+                class="button button-full button-positive"
+                style="font-weight:600"
+                ng-click="shareEnrollSocial('sms')"
+              >
+                <i style="float:left;" class="icon ion-ios-chatboxes-outline"></i>{{'SMS' | translate}}
+              </button>
+              <button
+                class="button button-full button-positive"
+                style="font-weight:600"
+                ng-click="shareEnrollSocial('copy')"
+              >
+                <i style="float:left;" class="icon ion-ios-copy-outline"></i>{{'Copy Message' | translate}}
+              </button>
+              <button
+                class="button button-full button-positive"
+                style="margin-top:40px;font-weight:600"
+                ng-click="shareEnrollSocial('cancel')"
+              >
+                {{'Cancel' | translate}}
+              </button>
+            </div>
+          </div>
+        </div>
+      </ion-content>
+    </ion-modal-view>
+  </script>
 </ion-view>


### PR DESCRIPTION
## Summary
- expose enroll URL sharing data with placeholder replacement in the notifications payload
- wire the enroll card on the home view to a sharing modal that displays the message and url
- provide native and web share options (copy, whatsapp, email, sms) via the new modal

## Testing
- php -l controllers/Mobile/ViewController.php

------
https://chatgpt.com/codex/tasks/task_e_68da1e5b5f00832db8611b7a0ea38533