### PR TITLE
Use DB affinity settings for scoring; improve prompt, parsing, and edge upserts

### DIFF
--- a/Model/Db/Table/Affinity.php
+++ b/Model/Db/Table/Affinity.php
@@ -177,7 +177,7 @@ class Migareference_Model_Db_Table_Affinity extends Core_Model_Db_Table
             `raw_response` = VALUES(`raw_response`),
             `updated_at` = VALUES(`updated_at`)";
         try {
-            $this->_db->query($sql, [
+            $statement = $this->_db->query($sql, [
                 (int) $app_id,
                 (int) $run_id,
                 $low,
@@ -190,7 +190,7 @@ class Migareference_Model_Db_Table_Affinity extends Core_Model_Db_Table
         } catch (Exception $e) {
             throw new Exception('Affinity edge upsert failed: ' . $e->getMessage(), 0, $e);
         }
-        return true;
+        return $statement->rowCount();
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Replace legacy call-script values with the new affinity settings stored in DB so runtime scoring uses `affinity_enabled`, `affinity_model`, `affinity_temperature`, `affinity_max_tokens`, `affinity_user_prompt`, and `affinity_system_prompt`.
- Make scoring prompts and response parsing more robust and deterministic to avoid bad provider responses and ensure valid scores in the 1..10 range.

### Description
- Load affinity settings via a new helper `loadAffinitySettings($app_id, $overrides=[])` and return a consistent settings structure and `enabled` flag; return a JSON error with message "Affinity engine is disabled in settings" when `affinity_enabled != 1` for both `/public_affinity/cronrunner` and `/process` endpoints (controllers/Public/AffinityController.php).
- Pass `affinity_model`, `affinity_temperature`, `affinity_max_tokens`, `affinity_user_prompt`, and `affinity_system_prompt` into the scoring service instead of the old call-script config and allow per-request overrides where provided (controllers/Public/AffinityController.php and Model/AffinityScoringService.php).
- Enforce prompt correctness and placeholders: `buildPrompt` now supports placeholder replacement (`applyTemplate`) and appends a wrapper that requires ONLY JSON with schema `{"scores":[{"compare_id":<int>,"score":<int 1..10>}]}`, includes rubric text `1 conflict, 2–5 weak/adjacent, 6–8 good strategic, 9–10 highly complementary`, and explicitly states `NO markdown, NO code fences` (Model/AffinityScoringService.php).
- Improve parsing robustness by stripping ```json fences and extracting the first JSON object found before `json_decode` via `extractJsonPayload`, and increment an internal parse/error counter for invalid entries (Model/AffinityScoringService.php).
- Support endpoint/model mismatch checks: detect endpoint type from `api_url` (`/v1/chat/completions` vs `/v1/completions`) and validate the chosen model is appropriate for that endpoint, failing with a clear error if mismatched (Model/AffinityScoringService.php).
- Make affinity edge upsert return affected row counts (`rowCount`) and use that to compute `inserted_edges_count`; if zero edges were inserted set a `last_error` and include a truncated `raw_provider_response_sample` (controllers/Public/AffinityController.php and Model/Db/Table/Affinity.php).
- Add diagnostics propagated in responses so endpoints always include `provider`, `http_status`, `openai_requests_made`, `inserted_edges_count`, `errors_count`, `last_error`, and `raw_provider_response_sample` (controllers/Public/AffinityController.php).

### Testing
- No automated tests were run on the modified code as part of this change set.
- Manual review performed by reading changed controller/service/table logic to verify the new branches and diagnostics were wired through correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671f1d2478832d871be4a5ade151f6)