### PR TITLE
Add 'View Matches' modal + server-side matchings endpoint for referrer phonebook

### DIFF
--- a/Model/Affinity.php
+++ b/Model/Affinity.php
@@ -53,6 +53,17 @@ class Migareference_Model_Affinity extends Core_Model_Default
     }
 
     /**
+     * Fetch the most recent completed affinity run for an app.
+     *
+     * @param int $app_id
+     * @return array|null
+     */
+    public function getLatestCompletedRun($app_id)
+    {
+        return $this->getTable()->getLatestCompletedRun($app_id);
+    }
+
+    /**
      * Acquire a run lock for cron processing.
      *
      * @param int $run_id
@@ -129,6 +140,34 @@ class Migareference_Model_Affinity extends Core_Model_Default
     public function getReferrerProfiles($appId, array $referrerIds)
     {
         return $this->getTable()->getReferrerProfiles($appId, $referrerIds);
+    }
+
+    /**
+     * Fetch contact profile rows for a set of referrer ids.
+     *
+     * @param int $appId
+     * @param array $referrerIds
+     * @return array
+     */
+    public function getReferrerContactProfiles($appId, array $referrerIds)
+    {
+        return $this->getTable()->getReferrerContactProfiles($appId, $referrerIds);
+    }
+
+    /**
+     * Fetch paginated affinity matchings for a referrer.
+     *
+     * @param int $app_id
+     * @param int $run_id
+     * @param int $referrer_id
+     * @param int $start
+     * @param int $length
+     * @param string|null $search
+     * @return array
+     */
+    public function getAffinityMatchings($app_id, $run_id, $referrer_id, $start, $length, $search = null)
+    {
+        return $this->getTable()->getAffinityMatchings($app_id, $run_id, $referrer_id, $start, $length, $search);
     }
 
     /**

--- a/controllers/ApplicationController.php
+++ b/controllers/ApplicationController.php
@@ -7543,7 +7543,8 @@ public function getmanageprizeAction() {
                   && $datediff>=$min_ref_last_contact_filter && $datediff<=$max_ref_last_contact_filter) {
                   $is_profiled = ( $value['job_id']>0 && $value['rating']>0) ?  $profiled: $not_profiled ;                  
                   $is_profiled_bol = ( $value['job_id']>0 && $value['rating']>0) ?  1: 0 ;                  
-                  $edit_action = '<button class="btn btn-info" onclick="editProspectJob('.$value['migarefrence_phonebook_id'].',1,'.$value['terms_accepted'].','.$value['user_id'].','.$is_profiled_bol.')">'."<i class='fa fa-edit'></i>".'</button>';                                    
+                  $edit_action = '<button class="btn btn-info" onclick="editProspectJob('.$value['migarefrence_phonebook_id'].',1,'.$value['terms_accepted'].','.$value['user_id'].','.$is_profiled_bol.')">'."<i class='fa fa-edit'></i>".'</button>';
+                  $view_matches = '<button class="btn btn-info view-matches-btn" data-referrer-id="'.$value['user_id'].'" title="'.__('View Matches').'">'."<i class='fa fa-users'></i>".'</button>';                                    
                   $ref_user='<select id="" class="input-flat" name="" onChange="showProspectEdit(this)" >';
                   $ref_user.='<option  value="0"></option>';
                       foreach ($connected_prospect as $key => $valuee):
@@ -7584,7 +7585,7 @@ public function getmanageprizeAction() {
               
                     
                     $report_collection_item=[
-                                      $edit_action,
+                                      $edit_action.' '.$view_matches,
                                       // $edit_action,
                                       $is_profiled.' '.$is_terms_accepted.' '.$value['firstname']." ".$value['lastname'],
                                       $value['mobile'],

--- a/resources/design/desktop/flat/template/migareference/application/edit.phtml
+++ b/resources/design/desktop/flat/template/migareference/application/edit.phtml
@@ -10674,6 +10674,35 @@
             </div>
         </div>
     </div>
+    <div id="affinityMatchesModal" class="modal" style="background:#00000047;display:none;">
+        <div class="modal-content" style="width: 70%;left: 15%;top: 15%;height:70%;overflow:auto;">
+            <div class="modal-header" style="padding:0;">
+                <span onClick="closeAffinityMatchesModal()" style="margin-top: -2px;color: red;text-align: center;height: 23px;width: 33px;opacity: 1;"
+                    class="close">&times;</span>
+                <h4 style="text-align:center;"><?php echo __("Top Matching Referrers") ?></h4>
+                <div style="padding:10px 20px;text-align:center;">
+                    <button id="affinity-top10-btn" class="btn color-blue" type="button"><?php echo __("Top 10") ?></button>
+                    <button id="affinity-all-btn" class="btn" type="button"><?php echo __("View All Matchings") ?></button>
+                </div>
+            </div>
+            <div class="modal-body" style="padding:20px;">
+                <table id="migareference_affinity_matches_table" class="table display responsive nowrap content-white-bkg"
+                    style="width:100%">
+                    <thead>
+                        <tr class="border-grey">
+                            <th><?php echo __('Score'); ?></th>
+                            <th><?php echo __('Referrer Name'); ?></th>
+                            <th><?php echo __('Email'); ?></th>
+                            <th><?php echo __('Phone'); ?></th>
+                            <th><?php echo __('Job / Sector'); ?></th>
+                            <th><?php echo __('Agent'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody></tbody>
+                </table>
+            </div>
+        </div>
+    </div>
     <!-- Manage Deleted Users Modal -->
     <div id="deletedusersModal" class="modal">
         <!-- Modal content -->
@@ -15696,6 +15725,89 @@ function loadreferrerphonebook() {
     var referrer_table = $('#migarefrence_referrel_phonebook').DataTable(dt_object_first_order);
 }
 loadreferrerphonebook();
+
+var affinityMatchesTable = null;
+var affinityMatchesReferrerId = 0;
+var affinityMatchesPageSize = 10;
+
+function toggleAffinityMatchButtons(isTopTen) {
+    if (isTopTen) {
+        $("#affinity-top10-btn").addClass("color-blue");
+        $("#affinity-all-btn").removeClass("color-blue");
+    } else {
+        $("#affinity-top10-btn").removeClass("color-blue");
+        $("#affinity-all-btn").addClass("color-blue");
+    }
+}
+
+function initAffinityMatchesTable() {
+    if (!affinityMatchesReferrerId) {
+        return;
+    }
+    if (affinityMatchesTable) {
+        affinityMatchesTable.page.len(affinityMatchesPageSize).draw();
+        return;
+    }
+    affinityMatchesTable = $('#migareference_affinity_matches_table').DataTable({
+        processing: true,
+        serverSide: true,
+        searching: true,
+        lengthChange: false,
+        pageLength: affinityMatchesPageSize,
+        order: [[0, "desc"]],
+        ajax: {
+            url: '<?php echo $this->getUrl('migareference/phonebook/matchings'); ?>',
+            type: 'GET',
+            data: function(d) {
+                d.app_id = <?php echo (int) $app_id; ?>;
+                d.referrer_id = affinityMatchesReferrerId;
+            }
+        },
+        language: {
+            "emptyTable": "<?php echo __js("No matching referrers found"); ?>"
+        }
+    });
+}
+
+function openAffinityMatchesModal(referrerId) {
+    affinityMatchesReferrerId = parseInt(referrerId, 10) || 0;
+    affinityMatchesPageSize = 10;
+    toggleAffinityMatchButtons(true);
+    document.getElementById("affinityMatchesModal").style.display = "block";
+    initAffinityMatchesTable();
+    if (affinityMatchesTable) {
+        affinityMatchesTable.ajax.reload();
+    }
+}
+
+function closeAffinityMatchesModal() {
+    document.getElementById("affinityMatchesModal").style.display = "none";
+}
+
+$("#migarefrence_referrel_phonebook").on("click", ".view-matches-btn", function() {
+    var referrerId = $(this).data("referrer-id");
+    openAffinityMatchesModal(referrerId);
+});
+
+$("#affinity-top10-btn").on("click", function() {
+    affinityMatchesPageSize = 10;
+    toggleAffinityMatchButtons(true);
+    if (affinityMatchesTable) {
+        affinityMatchesTable.page.len(affinityMatchesPageSize).draw();
+    } else {
+        initAffinityMatchesTable();
+    }
+});
+
+$("#affinity-all-btn").on("click", function() {
+    affinityMatchesPageSize = 50;
+    toggleAffinityMatchButtons(false);
+    if (affinityMatchesTable) {
+        affinityMatchesTable.page.len(affinityMatchesPageSize).draw();
+    } else {
+        initAffinityMatchesTable();
+    }
+});
 
 function chnageRedeemstatus(obj) {
     key = obj.value;


### PR DESCRIPTION
### Motivation
- Provide admins a quick way to inspect top matching referrers for any referrer directly from the referrer phonebook UI using existing affinity scoring data.
- Support scalable lookups via server-side DataTables with search, paging and a Top-10 / View-All toggle.

### Description
- UI: added a per-row "View Matches" action button (multi-user icon, title `View Matches`) in the referrer phonebook list and a new modal (`#affinityMatchesModal`) that renders a DataTable for matches with columns Score, Referrer Name, Email, Phone, Job/Sector and Agent, plus "Top 10" / "View All Matchings" header buttons; front-end JS initializes and reloads a server-side DataTable and toggles page size.
- Controller: added `matchingsAction` in `migareference/phonebook` to serve DataTables JSON; it validates `app_id`/`referrer_id`, enforces admin permissions, selects latest completed run fallback to running run, applies DataTables params (draw/start/length/search) and returns `draw`, `recordsTotal`, `recordsFiltered`, and `data`.
- Model/db helpers: extended `Model/Db/Table/Affinity.php` with `getLatestCompletedRun`, `getReferrerContactProfiles`, and `getAffinityMatchings` (bulk profile fetch and paginated, searchable affinity edge query); exposed facades in `Model/Affinity.php` (`getLatestCompletedRun`, `getReferrerContactProfiles`, `getAffinityMatchings`).
- Integration: controller uses the affinity model to fetch match edges, bulk-fetch matched referrer profiles for the current page, formats rows for DataTables, and returns empty result set when no run/edges exist; UI wires the new button events to open the modal and load the server-side table.
- Security & validation: admin-only access enforced via existing `is_admin` check, `app_id` and `referrer_id` numeric validation, and graceful empty responses when no run is available; translations use `__()`/`__js()` where applicable.

### Testing
- No automated tests were executed for this change in this rollout (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69672c609274832d88ea9c60176658f1)