### PR TITLE
Chunk affinity scoring requests and use geo names

### DIFF
--- a/Model/AffinityScoringService.php
+++ b/Model/AffinityScoringService.php
@@ -287,13 +287,23 @@ class Migareference_Model_AffinityScoringService
 
     private function normalizeProfile(array $profile)
     {
+        $province = $this->stringValue($profile['province'] ?? '');
+        $country = $this->stringValue($profile['country'] ?? '');
+        // Guard against numeric IDs leaking into the model prompt.
+        if ($province !== '' && is_numeric($province)) {
+            $province = '';
+        }
+        if ($country !== '' && is_numeric($country)) {
+            $country = '';
+        }
+
         return [
             'name' => $this->stringValue($profile['name'] ?? ''),
             'surname' => $this->stringValue($profile['surname'] ?? ''),
             'job' => $this->stringValue($profile['job'] ?? ''),
             'profession' => $this->stringValue($profile['profession'] ?? ''),
-            'province' => $this->stringValue($profile['province'] ?? ''),
-            'country' => $this->stringValue($profile['country'] ?? ''),
+            'province' => $province,
+            'country' => $country,
             'notes' => $this->stringValue($profile['notes'] ?? ''),
             'reciprocity_notes' => $this->stringValue($profile['reciprocity_notes'] ?? ''),
             'rating' => isset($profile['rating']) ? (int) $profile['rating'] : 0,

--- a/Model/Db/Table/Affinity.php
+++ b/Model/Db/Table/Affinity.php
@@ -265,7 +265,10 @@ class Migareference_Model_Db_Table_Affinity extends Core_Model_Db_Table
             ph.rating,
             jobs.job_title,
             prof.profession_title,
-            prov.province,
+            prov.province AS province_name,
+            prov.province_code,
+            geoc.country AS country_name,
+            geoc.country_code,
             inv.address_country_id
           FROM `migarefrence_phonebook` AS ph
           JOIN `migareference_invoice_settings` AS inv
@@ -277,6 +280,8 @@ class Migareference_Model_Db_Table_Affinity extends Core_Model_Db_Table
             ON prof.migareference_professions_id = ph.profession_id
           LEFT JOIN `migareference_geo_provinces` AS prov
             ON prov.migareference_geo_provinces_id = inv.address_province_id
+          LEFT JOIN `migareference_geo_countries` AS geoc
+            ON geoc.migareference_geo_countries_id = inv.address_country_id
           WHERE ph.app_id = ?
             AND ph.type = 1
             AND inv.user_id IN ($placeholders)

--- a/controllers/OpenaiController.php
+++ b/controllers/OpenaiController.php
@@ -511,8 +511,9 @@ class Migareference_OpenaiController extends Application_Controller_Default{
             'surname' => $this->stringValue($row['surname'] ?? ''),
             'job' => $this->stringValue($row['job_title'] ?? ''),
             'profession' => $this->stringValue($row['profession_title'] ?? ''),
-            'province' => $this->stringValue($row['province'] ?? ''),
-            'country' => $this->stringValue($row['address_country_id'] ?? ''),
+            // Use names (not numeric IDs) so the model sees real locations.
+            'province' => $this->stringValue($row['province_name'] ?? ''),
+            'country' => $this->stringValue($row['country_name'] ?? ''),
             'notes' => $this->stringValue($note),
             'reciprocity_notes' => $this->stringValue($row['reciprocity_notes'] ?? ''),
             'rating' => isset($row['rating']) ? (int) $row['rating'] : 0,


### PR DESCRIPTION
### Motivation
- Prevent oversized OpenAI requests from producing truncated/invalid JSON by limiting the number of compare profiles sent per request and continuing the run when a chunk fails. 
- Ensure the affinity scoring model receives readable location values by sending country/province names (and optionally codes) instead of numeric IDs. 
- Preserve existing run/edge persistence behavior while improving prompt quality and error visibility.

### Description
- Add `MAX_COMPARE_PER_REQUEST = 30` in `controllers/Public/AffinityController.php` and change `processPairGroup()` to chunk `compare_ids` via `array_chunk()` and call `scoreBatch()` once per chunk. 
- For each chunk build `compareProfiles` from `getReferrerProfiles()` results, call `Migareference_Model_AffinityScoringService::scoreBatch()`, upsert edges for that chunk only with `upsertAffinityEdge()`, and accumulate `openai_requests_made`, `errors_count`, `inserted_edges_count`, `last_insert_pair`, and merged `scores`/`errors`. 
- On per-chunk failures (including invalid/truncated JSON) the code continues to the next chunk and records an error entry containing `primary_id`, chunk compare count/first/last ids, `last_error`, `http_status`, `provider`, and a `raw_response_sample` (first 500 chars). 
- Update `Model/Db/Table/Affinity::getReferrerProfiles()` SQL to LEFT JOIN `migareference_geo_provinces` and `migareference_geo_countries` and return `province_name`, `province_code`, `country_name`, and `country_code`. 
- Update `buildAffinityProfile()` in `controllers/Public/AffinityController.php` and `controllers/OpenaiController.php` to map `province`/`country` to the returned name fields (e.g. `province_name`, `country_name`) and add inline comments explaining why names are used. 
- Harden `Migareference_Model_AffinityScoringService::normalizeProfile()` to ensure `province`/`country` are strings and to drop numeric values if they leak through, preventing numeric IDs from being sent in the model prompt. 
- Preserve existing `updateAffinityRun()` and `upsertAffinityEdge()` usage and keep return structure compatible (merged `scores` map, merged `errors`, `raw_response_sample` is the last chunk sample).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696758d7b2e8832d9186d44bb853fa24)