### PR TITLE
Fix affinity matchings authorization and include required params

### DIFF
--- a/controllers/PhonebookController.php
+++ b/controllers/PhonebookController.php
@@ -104,12 +104,28 @@ class Migareference_PhonebookController extends Application_Controller_Default{
         if (!$app_id && $this->getApplication()) {
             $app_id = (int) $this->getApplication()->getId();
         }
+        $value_id = (int) $this->getRequest()->getParam('value_id');
+        if (!$value_id) {
+            $value_id = (int) $this->getRequest()->getParam('option_id');
+        }
         $referrer_id = (int) $this->getRequest()->getParam('referrer_id');
-        if (!$app_id || !$referrer_id) {
+        if (!$app_id || !$referrer_id || !$value_id) {
             throw new Exception(__('Invalid request.'));
         }
 
         $user_id = isset($_SESSION['front']['object_id']) ? (int) $_SESSION['front']['object_id'] : 0;
+        if (!$user_id && method_exists($this, 'getSession')) {
+            $session = $this->getSession();
+            if ($session && method_exists($session, 'getCustomerId')) {
+                $user_id = (int) $session->getCustomerId();
+            }
+        }
+        if (!$user_id && isset($_SESSION['backoffice']['user_id'])) {
+            $user_id = (int) $_SESSION['backoffice']['user_id'];
+        }
+        if (!$user_id && isset($_SESSION['admin']['user_id'])) {
+            $user_id = (int) $_SESSION['admin']['user_id'];
+        }
         if (!$user_id) {
             throw new Exception(__('Unauthorized.'));
         }
@@ -216,6 +232,9 @@ class Migareference_PhonebookController extends Application_Controller_Default{
             'data' => $data,
         ]);
     } catch (\Exception $e) {
+        if (method_exists($this, 'getResponse')) {
+            $this->getResponse()->setHttpResponseCode(200);
+        }
         $this->_sendJson([
             'draw' => $draw,
             'recordsTotal' => 0,

--- a/resources/design/desktop/flat/template/migareference/application/edit.phtml
+++ b/resources/design/desktop/flat/template/migareference/application/edit.phtml
@@ -15760,6 +15760,8 @@ function initAffinityMatchesTable() {
             type: 'GET',
             data: function(d) {
                 d.app_id = <?php echo (int) $app_id; ?>;
+                d.value_id = <?php echo (int) $option->getId(); ?>;
+                d.option_id = <?php echo (int) $option->getId(); ?>;
                 d.referrer_id = affinityMatchesReferrerId;
             }
         },


### PR DESCRIPTION
### Motivation
- The affinity matchings DataTable was triggering a GET to the admin controller without required identifiers, causing the controller to reject the request as `Unauthorized.` and the UI to break. 
- The controller authorization logic expected an application/value identifier and a valid session (admin/backoffice/customer) which the previous client code did not always provide.

### Description
- Added `value_id` and `option_id` query parameters to the affinity matchings DataTable request in `resources/design/desktop/flat/template/migareference/application/edit.phtml` so the controller receives the value context. 
- In `controllers/PhonebookController.php` `matchingsAction` now reads `value_id` (falling back to `option_id`) and requires it along with `app_id` and `referrer_id` before proceeding. 
- Expanded session detection to accept `front` session, `getSession()->getCustomerId()` if available, and `backoffice`/`admin` session keys so backoffice-initiated requests can be authorized. 
- Kept the `is_admin` check but normalized error handling to always return a DataTables-shaped JSON response (fields `draw`, `recordsTotal`, `recordsFiltered`, `data`) and ensure the HTTP response code is 200 on errors so the DataTable UI does not break.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69675c206ac0832db6f1b992e914b681)