### PR TITLE
Fix affinity matches DataTable init and secure matchings API

### DIFF
--- a/controllers/PhonebookController.php
+++ b/controllers/PhonebookController.php
@@ -104,12 +104,28 @@ class Migareference_PhonebookController extends Application_Controller_Default{
         if (!$app_id && $this->getApplication()) {
             $app_id = (int) $this->getApplication()->getId();
         }
+        $value_id = (int) $this->getRequest()->getParam('value_id');
+        if (!$value_id) {
+            $value_id = (int) $this->getRequest()->getParam('option_id');
+        }
         $referrer_id = (int) $this->getRequest()->getParam('referrer_id');
-        if (!$app_id || !$referrer_id) {
+        if (!$app_id || !$referrer_id || !$value_id) {
             throw new Exception(__('Invalid request.'));
         }
 
         $user_id = isset($_SESSION['front']['object_id']) ? (int) $_SESSION['front']['object_id'] : 0;
+        if (!$user_id && method_exists($this, 'getSession')) {
+            $session = $this->getSession();
+            if ($session && method_exists($session, 'getCustomerId')) {
+                $user_id = (int) $session->getCustomerId();
+            }
+        }
+        if (!$user_id && isset($_SESSION['backoffice']['user_id'])) {
+            $user_id = (int) $_SESSION['backoffice']['user_id'];
+        }
+        if (!$user_id && isset($_SESSION['admin']['user_id'])) {
+            $user_id = (int) $_SESSION['admin']['user_id'];
+        }
         if (!$user_id) {
             throw new Exception(__('Unauthorized.'));
         }
@@ -216,6 +232,9 @@ class Migareference_PhonebookController extends Application_Controller_Default{
             'data' => $data,
         ]);
     } catch (\Exception $e) {
+        if (method_exists($this, 'getResponse')) {
+            $this->getResponse()->setHttpResponseCode(200);
+        }
         $this->_sendJson([
             'draw' => $draw,
             'recordsTotal' => 0,

--- a/resources/design/desktop/flat/template/migareference/application/edit.phtml
+++ b/resources/design/desktop/flat/template/migareference/application/edit.phtml
@@ -15744,29 +15744,23 @@ function initAffinityMatchesTable() {
     if (!affinityMatchesReferrerId) {
         return;
     }
-    if (affinityMatchesTable) {
-        affinityMatchesTable.page.len(affinityMatchesPageSize).draw();
-        return;
+    if ($.fn.DataTable.isDataTable('#migareference_affinity_matches_table')) {
+        $('#migareference_affinity_matches_table').DataTable().destroy();
     }
-    affinityMatchesTable = $('#migareference_affinity_matches_table').DataTable({
-        processing: true,
-        serverSide: true,
-        searching: true,
-        lengthChange: false,
-        pageLength: affinityMatchesPageSize,
-        order: [[0, "desc"]],
-        ajax: {
-            url: '<?php echo $this->getUrl('migareference/phonebook/matchings'); ?>',
-            type: 'GET',
-            data: function(d) {
-                d.app_id = <?php echo (int) $app_id; ?>;
-                d.referrer_id = affinityMatchesReferrerId;
-            }
-        },
-        language: {
-            "emptyTable": "<?php echo __js("No matching referrers found"); ?>"
-        }
+    var dt_affinity_matches = $.extend(true, {}, dt_object_first_order);
+    dt_affinity_matches.processing = true;
+    dt_affinity_matches.serverSide = true;
+    dt_affinity_matches.searching = true;
+    dt_affinity_matches.lengthChange = false;
+    dt_affinity_matches.pageLength = affinityMatchesPageSize;
+    dt_affinity_matches.order = [[0, "desc"]];
+    dt_affinity_matches.ajax =
+        '<?php echo $this->getUrl('migareference/phonebook/matchings?app_id=' . $app_id . '&value_id=' . $option->getId() . '&option_id=' . $option->getId()); ?>' +
+        '&referrer_id=' + affinityMatchesReferrerId;
+    dt_affinity_matches.language = $.extend(true, {}, dt_affinity_matches.language, {
+        "emptyTable": "<?php echo __js("No matching referrers found"); ?>"
     });
+    affinityMatchesTable = $('#migareference_affinity_matches_table').DataTable(dt_affinity_matches);
 }
 
 function openAffinityMatchesModal(referrerId) {


### PR DESCRIPTION
### Motivation
- The affinity matches DataTable was intermittently sending requests without required identifiers and reusing stale table state, causing authorization failures and UI errors.
- The `matchingsAction` needed more robust session/user detection and consistent error responses to keep the DataTable UI from breaking on errors.

### Description
- Rebuilt the affinity matches client initialization to always destroy and recreate the DataTable, reusing the shared `dt_object_first_order` config and setting server-side options before instantiation in `resources/design/desktop/flat/template/migareference/application/edit.phtml`.
- Included required identifiers in the matchings request URL by adding `app_id`, `value_id`, and `option_id` and appending `referrer_id` to the URL string when creating the DataTable AJAX source.
- Updated `matchingsAction` in `controllers/PhonebookController.php` to read `value_id` (falling back to `option_id`), require it alongside `app_id` and `referrer_id`, and expand session detection to use front session, `getSession()->getCustomerId()`, and `backoffice`/`admin` session keys for authorization.
- Normalized error handling in `matchingsAction` to return a DataTables-shaped JSON payload (`draw`, `recordsTotal`, `recordsFiltered`, `data`) and set the HTTP response code to 200 on exceptions so the DataTable client does not break.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69675c206ac0832db6f1b992e914b681)